### PR TITLE
EC Public key Extractor

### DIFF
--- a/wallet-unit-poc/circom/circuits/ec-extractor.circom
+++ b/wallet-unit-poc/circom/circuits/ec-extractor.circom
@@ -1,0 +1,52 @@
+pragma circom 2.1.6;
+
+include "keyless_zk_proofs/arrays.circom";
+include "circomlib/circuits/comparators.circom";
+include "utils.circom";
+
+template ECPublicKeyExtractor(maxPayloadLength, valueCharLen, expectedB64Len, coordinateByteLen) {
+    signal input payload[maxPayloadLength];
+    signal input xStartIndex;
+    signal input yStartIndex;
+
+    signal output pubKeyX;
+    signal output pubKeyY;
+
+    signal xValueEnd <== xStartIndex + expectedB64Len;
+    signal yValueEnd <== yStartIndex + expectedB64Len;
+
+    component xWithinBounds = LessThan(log2Ceil(maxPayloadLength));
+    xWithinBounds.in[0] <== xValueEnd;
+    xWithinBounds.in[1] <== maxPayloadLength;
+    xWithinBounds.out === 1;
+
+    component yWithinBounds = LessThan(log2Ceil(maxPayloadLength));
+    yWithinBounds.in[0] <== yValueEnd;
+    yWithinBounds.in[1] <== maxPayloadLength;
+    yWithinBounds.out === 1;
+
+    component xExtractor = ExtractBase64UrlValue(maxPayloadLength, valueCharLen, expectedB64Len);
+    xExtractor.payload <== payload;
+    xExtractor.startIndex <== xStartIndex;
+
+    component yExtractor = ExtractBase64UrlValue(maxPayloadLength, valueCharLen, expectedB64Len);
+    yExtractor.payload <== payload;
+    yExtractor.startIndex <== yStartIndex;
+
+    component decodeX = DecodeSD(valueCharLen, coordinateByteLen);
+    decodeX.sdBytes <== xExtractor.value;
+    decodeX.sdLen <== xExtractor.valueLength;
+
+    component decodeY = DecodeSD(valueCharLen, coordinateByteLen);
+    decodeY.sdBytes <== yExtractor.value;
+    decodeY.sdLen <== yExtractor.valueLength;
+
+    component xToNumber = BytesToNumberBE(coordinateByteLen);
+    xToNumber.in <== decodeX.base64Out;
+
+    component yToNumber = BytesToNumberBE(coordinateByteLen);
+    yToNumber.in <== decodeY.base64Out;
+
+    pubKeyX <== xToNumber.out;
+    pubKeyY <== yToNumber.out;
+}

--- a/wallet-unit-poc/circom/circuits/jwt.circom
+++ b/wallet-unit-poc/circom/circuits/jwt.circom
@@ -70,11 +70,11 @@ template JWT(
     signal xValueStart <== matchIndex[0] + matchLength[0];
     signal yValueStart <== matchIndex[1] + matchLength[1];
 
-    // 32-byte coordinate -> ceil(32 * 4 / 3) = 43 base64url chars
+    // 32-byte coordinate -> 44 base64 characters (padding optional -> 43 or 44)
     signal xValueEnd <== xValueStart + 43;
     signal yValueEnd <== yValueStart + 43; 
 
-    component ecExtractor = ECPublicKeyExtractor(maxPayloadLength, maxClaimsLength, 43, 32);
+    component ecExtractor = ECPublicKeyExtractor(maxPayloadLength, maxClaimsLength, 44, 32);
     ecExtractor.payload <== extractor.payload;
     ecExtractor.xStartIndex <== xValueStart;
     ecExtractor.yStartIndex <== yValueStart;

--- a/wallet-unit-poc/circom/circuits/jwt.circom
+++ b/wallet-unit-poc/circom/circuits/jwt.circom
@@ -1,13 +1,13 @@
 pragma circom 2.1.6;
 
 include "es256.circom";
-include "jwt_tx_builder/header-payload-extractor.circom";
-include "jwt_tx_builder/array.circom";
-include "keyless_zk_proofs/arrays.circom";
+include "keyless_zk_proofs/hashtofield.circom";
 include "@zk-email/circuits/lib/sha.circom";
 include "claim-decoder.circom";
 include "age-verifier.circom";
 include "utils.circom";
+include "payload_matcher.circom";
+include "ec-extractor.circom";
 
 // Prepare Circuit
 template JWT(
@@ -20,6 +20,7 @@ template JWT(
     maxClaimsLength
 ) {
     var decodedLen = (maxClaimsLength * 3) / 4;
+    var maxPayloadLength = (maxB64PayloadLength * 3) / 4;
 
     signal input message[maxMessageLength]; // JWT message (header + payload)
     signal input messageLength; // Length of the message signed in the JWT
@@ -39,16 +40,10 @@ template JWT(
     signal input claimLengths[maxMatches];
     signal input decodeFlags[maxMatches];
 
-    component claimDecoder = ClaimDecoder(maxMatches, maxClaimsLength);
-    claimDecoder.claims <== claims;
-    claimDecoder.claimLengths <== claimLengths;
-    claimDecoder.decodeFlags <== decodeFlags;
-
-
-    component claimHasher = ClaimHasher(maxMatches, maxClaimsLength);
-    claimHasher.claims <== claims;
-           
-    ClaimComparator(maxMatches, maxSubstringLength)(claimHasher.claimHashes ,claimLengths, matchSubstring, matchLength);
+   
+    signal decodedClaims[maxMatches][decodedLen] <== ClaimDecoder(maxMatches, maxClaimsLength)(claims, claimLengths, decodeFlags);
+    signal claimHashes[maxMatches][32] <== ClaimHasher(maxMatches, maxClaimsLength)(claims);
+    ClaimComparator(maxMatches, maxSubstringLength)(claimHashes ,claimLengths, matchSubstring, matchLength);
 
     component es256 = ES256(maxMessageLength);
     es256.message <== message;
@@ -63,24 +58,27 @@ template JWT(
     extractor.messageLength <== messageLength;
     extractor.periodIndex <== periodIndex;    
 
-    component enableMacher[maxMatches];
-    component matcher[maxMatches];
-    var       maxPayloadLength = (maxB64PayloadLength * 3) \ 4;
 
-    for (var i=0;i<maxMatches;i++) {
-        enableMacher[i] = LessThan(8);
-        enableMacher[i].in[0] <== i;
-        enableMacher[i].in[1] <== matchesCount;
+    signal payloadHash <== PayloadSubstringMatcher(maxPayloadLength, maxMatches, maxSubstringLength)(
+        extractor.payload,
+        matchesCount,
+        matchSubstring,
+        matchLength,
+        matchIndex
+    );
 
-        matcher[i] = CheckSubstrInclusionPoly(maxPayloadLength,maxSubstringLength);
-        matcher[i].str <== extractor.payload;
-        matcher[i].str_hash <== 81283812381238128;
-        matcher[i].substr <== matchSubstring[i];
-        matcher[i].substr_len <== matchLength[i];
-        matcher[i].start_index <== matchIndex[i];
-        matcher[i].enabled <== enableMacher[i].out;
-    }
+    signal xValueStart <== matchIndex[0] + matchLength[0];
+    signal yValueStart <== matchIndex[1] + matchLength[1];
 
-    signal output jwtClaims[maxMatches][decodedLen];
-    jwtClaims <==  claimDecoder.decodedClaims;
+    // 32-byte coordinate -> ceil(32 * 4 / 3) = 43 base64url chars
+    signal xValueEnd <== xValueStart + 43;
+    signal yValueEnd <== yValueStart + 43; 
+
+    component ecExtractor = ECPublicKeyExtractor(maxPayloadLength, maxClaimsLength, 43, 32);
+    ecExtractor.payload <== extractor.payload;
+    ecExtractor.xStartIndex <== xValueStart;
+    ecExtractor.yStartIndex <== yValueStart;
+
+    signal output KeyBindingX <== ecExtractor.pubKeyX;
+    signal output KeyBindingY <== ecExtractor.pubKeyY;
 }

--- a/wallet-unit-poc/circom/circuits/payload_matcher.circom
+++ b/wallet-unit-poc/circom/circuits/payload_matcher.circom
@@ -1,0 +1,35 @@
+include "jwt_tx_builder/header-payload-extractor.circom";
+include "jwt_tx_builder/array.circom";
+
+template PayloadSubstringMatcher(maxPayloadLength, maxMatches, maxSubstringLength) {
+
+    signal input payload[maxPayloadLength];
+    signal input matchesCount;
+    signal input matchSubstring[maxMatches][maxSubstringLength];
+    signal input matchLength[maxMatches];
+    signal input matchIndex[maxMatches];
+
+    signal output payloadHash;
+
+    component payloadHasher = HashBytesToFieldWithLen(maxPayloadLength);
+    payloadHasher.in <== payload;
+    payloadHasher.len <== maxPayloadLength;
+    payloadHash <== payloadHasher.hash;
+
+    component enableMatcher[maxMatches];
+    component matcher[maxMatches];
+
+    for (var i = 0; i < maxMatches; i++) {
+        enableMatcher[i] = LessThan(log2Ceil(maxMatches));
+        enableMatcher[i].in[0] <== i;
+        enableMatcher[i].in[1] <== matchesCount;
+
+        matcher[i] = CheckSubstrInclusionPoly(maxPayloadLength, maxSubstringLength);
+        matcher[i].str <== payload;
+        matcher[i].str_hash <== payloadHash;
+        matcher[i].substr <== matchSubstring[i];
+        matcher[i].substr_len <== matchLength[i];
+        matcher[i].start_index <== matchIndex[i];
+        matcher[i].enabled <== enableMatcher[i].out;
+    }
+}

--- a/wallet-unit-poc/circom/package.json
+++ b/wallet-unit-poc/circom/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/privacy-scaling-explorations/zkID"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--max-old-space-size=8192 npx mocha --timeout 900000",
+    "test": "NODE_OPTIONS=--max-old-space-size=16384 npx mocha --timeout 900000",
     "save_input_file": "npx ts-node src/save_inputs.ts",
     "compile:jwt": "bash scripts/compile.sh jwt",
     "compile:ecdsa": "bash scripts/compile.sh ecdsa",

--- a/wallet-unit-poc/circom/tests/age-jwt.test.ts
+++ b/wallet-unit-poc/circom/tests/age-jwt.test.ts
@@ -30,7 +30,7 @@ describe("Selective Disclosure", () => {
       circuit = await circomkit.WitnessTester(`JWT`, {
         file: "jwt",
         template: "JWT",
-        params: [1024 * 3, 256, 2200, 6, 50, 128],
+        params: [1024 * 3, 256, 2200, 8, 50, 128],
         recompile: RECOMPILE,
       });
       console.log("#constraints:", await circuit.getConstraintCount());
@@ -57,8 +57,8 @@ describe("Selective Disclosure", () => {
         y: "0WhT_VgvnhNNj9aabTn4E4enR-iqbCrQtY9UWqD4XJY",
       };
 
-      const params = generateJwtCircuitParams([1024 * 3, 256, 2200, 6, 50, 128]);
-      let decodeFlags = [0, 0, 1, 0, 0, 0];
+      const params = generateJwtCircuitParams([1024 * 3, 256, 2200, 8, 50, 128]);
+      let decodeFlags = [0, 0, 1, 0, 0, 0, 0, 0];
       let inputs = generateJwtInputs(params, token, jwk, hashedClaims, claims, decodeFlags);
 
       const witness = await circuit.calculateWitness(inputs);
@@ -72,7 +72,7 @@ describe("Selective Disclosure", () => {
       circuit = await circomkit.WitnessTester(`JWT`, {
         file: "jwt",
         template: "JWT",
-        params: [1024 * 3, 256, 2200, 6, 50, 128],
+        params: [1024 * 3, 256, 2200, 8, 50, 128],
         recompile: RECOMPILE,
       });
       console.log("#constraints:", await circuit.getConstraintCount());
@@ -99,8 +99,8 @@ describe("Selective Disclosure", () => {
         y: "0WhT_VgvnhNNj9aabTn4E4enR-iqbCrQtY9UWqD4XJY",
       };
 
-      const params = generateJwtCircuitParams([1024 * 3, 256, 2200, 6, 50, 128]);
-      let decodeFlags = [0, 0, 1, 0, 0, 0];
+      const params = generateJwtCircuitParams([1024 * 3, 256, 2200, 8, 50, 128]);
+      let decodeFlags = [0, 0, 1, 0, 0, 0, 0, 0];
       let inputs = generateJwtInputs(params, token, jwk, hashedClaims, claims, decodeFlags);
 
       const witness = await circuit.calculateWitness(inputs);

--- a/wallet-unit-poc/circom/tests/jwt.test.ts
+++ b/wallet-unit-poc/circom/tests/jwt.test.ts
@@ -30,7 +30,7 @@ describe("JWT Verifier", () => {
       circuit = await circomkit.WitnessTester(`JWT`, {
         file: "jwt",
         template: "JWT",
-        params: [2048, 256, 2000, 3, 50, 128],
+        params: [2048, 256, 2000, 4, 50, 128],
         recompile: RECOMPILE,
       });
       console.log("#constraints:", await circuit.getConstraintCount());
@@ -57,9 +57,9 @@ describe("JWT Verifier", () => {
         y: "mm3p9quG010NysYgK-CAQz2E-wTVSNeIHl_HvWaaM6I",
       };
 
-      const params = generateJwtCircuitParams([2048, 256, 2000, 3, 50, 128]);
+      const params = generateJwtCircuitParams([2048, 256, 2000, 4, 50, 128]);
 
-      const decodeFlags = [0, 1, 0];
+      const decodeFlags = [0, 0, 1, 0];
       const inputs = generateJwtInputs(params, token, jwk, hashedClaims, claims, decodeFlags);
 
       const witness = await circuit.calculateWitness(inputs);


### PR DESCRIPTION
1. added `PayloadSubstringMatcher` template that reuses a single payload hash across substring checks and returns the decoded payload slices cleanly
2. added `ECPublicKeyExtractor` template to extract the key binding public key
3. updated `ClaimComparator` so it only Base64 decodes entries that correspond to real claims and pad others with 'A' safely