### PR TITLE
update GitHub actions in CI workflows 

### DIFF
--- a/.github/workflows/jwt-es256-circom-tests.yaml
+++ b/.github/workflows/jwt-es256-circom-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.

Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0