### PR TITLE
perf(witness): skip actual generation during setup

### DIFF
--- a/wallet-unit-poc/ecdsa-spartan2/src/jwt_circuit.rs
+++ b/wallet-unit-poc/ecdsa-spartan2/src/jwt_circuit.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env::current_dir, fs::File, time::Instant};
+use std::{any::type_name, collections::HashMap, env::current_dir, fs::File, time::Instant};
 
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use circom_scotia::{reader::load_r1cs, synthesize};
@@ -25,6 +25,19 @@ impl SpartanCircuit<E> for JWTCircuit {
         let root = current_dir().unwrap().join("../circom");
         let witness_dir = root.join("build/jwt/jwt_js");
         let r1cs = witness_dir.join("jwt.r1cs");
+
+        // Detect if we're in setup phase (ShapeCS) or prove phase (SatisfyingAssignment)
+        // During setup, we only need constraint structure instead of actual witness values
+        let cs_type = type_name::<CS>();
+        let is_setup_phase = cs_type.contains("ShapeCS");
+
+        if is_setup_phase {
+            let r1cs = load_r1cs(r1cs);
+            // Pass None for witness during setup
+            synthesize(cs, r1cs, None)?;
+            return Ok(());
+        }
+
         let json_file = {
             let path = current_dir()
                 .unwrap()


### PR DESCRIPTION
## Problem
During the full [`run_circuit()`](https://github.com/privacy-ethereum/zkID/blob/4fb4d0a17e7852fd63ffd6020c810a4c75c0bba7/wallet-unit-poc/ecdsa-spartan2/src/setup.rs#L17-L49), the witness were generating twice:
- setup stage when running [`r1cs_shape()` from `Spartan2/zk_r1cs.rs`](https://github.com/therealyingtong/Spartan2/blob/19e8dbe5f163ab877cc643571e1136b861645a1f/src/bellpepper/zk_r1cs.rs#L106-L111)
https://github.com/privacy-ethereum/zkID/blob/4fb4d0a17e7852fd63ffd6020c810a4c75c0bba7/wallet-unit-poc/ecdsa-spartan2/src/setup.rs#L20
- prove stage when executing [`r1cs_instance_and_witness()` from `Spartan2/zk_r1cs.rs`](https://github.com/therealyingtong/Spartan2/blob/19e8dbe5f163ab877cc643571e1136b861645a1f/src/bellpepper/zk_r1cs.rs#L399-L403)
https://github.com/privacy-ethereum/zkID/blob/4fb4d0a17e7852fd63ffd6020c810a4c75c0bba7/wallet-unit-poc/ecdsa-spartan2/src/setup.rs#L34

This caused redundant expensive computations (e.g., ~1.6s * 2 for JWT circuit).

## Solution
Added phase detection in `synthesize()` to conditionally generate witness:
- Setup phase (`ShapeCS`): Pass None to circom-scotia for constraint extraction only. circom-scotia will use dummy values for witness
- Prove phase (`SatisfyingAssignment`): Generate real witness once when needed

Uses type-based detection via `type_name::<CS>()` to distinguish contexts.

## Performance Improvement (JWT Circuit)
For the entire Spartan2 {setup, prepare, prove, verify} times,
- Before: ~11.7s total (setup + prove with 2× witness generation)
- After: ~8.8s total (setup 5.2s, prove 3.5s with 1× witness generation)
- Improvement: ~2.85s faster (~24% reduction)

## Related Issues
- close #34 