### PR TITLE
chore: bump checkout to v6

### DIFF
--- a/.github/workflows/ecdsa-spartan2.yaml
+++ b/.github/workflows/ecdsa-spartan2.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updated actions/checkout from v5 to v6 in ecdsa-spartan2.yaml workflow.