### PR TITLE
docs: update openac implementation benchmarks

### DIFF
--- a/wallet-unit-poc/ecdsa-spartan2/README.md
+++ b/wallet-unit-poc/ecdsa-spartan2/README.md
@@ -70,7 +70,7 @@ cargo run --release -- benchmark-all
 
 ## Latest benchmark results
 
-MacBook Pro M4, 24 GB RAM. Generated against the current generalized-predicates
+MacBook Pro M5, 24 GB RAM. Generated against the current generalized-predicates
 circuits (`Show(2, 2, 8, 64)` + `JWT(maxMsg, ...)`) with the example predicate
 `roc_birthday <= 1070101`.
 
@@ -78,17 +78,17 @@ circuits (`Show(2, 2, 8, 64)` + `JWT(maxMsg, ...)`) with the example predicate
 
 | Step            |    1k |    2k |    4k |    8k |
 | --------------- | ----: | ----: | ----: | ----: |
-| Prove Prepare   | 1,128 | 1,867 | 3,638 | 7,365 |
-| Reblind Prepare |   365 |   690 | 1,438 | 3,280 |
-| Prove Show      |    55 |    52 |    54 |    62 |
-| Reblind Show    |    25 |    24 |    25 |    24 |
-| Verify Prepare  |   645 | 1,036 | 2,044 | 4,023 |
-| Verify Show     |    16 |    15 |    16 |    17 |
+| Prove Prepare   | 1,119 | 1,617 | 3,344 | 6,999 |
+| Reblind Prepare |   337 |   638 | 1,257 | 2,662 |
+| Prove Show      |    57 |    59 |    58 |    74 |
+| Reblind Show    |    26 |    24 |    25 |    25 |
+| Verify Prepare  |   740 | 1,170 | 2,229 | 4,769 |
+| Verify Show     |    19 |    18 |    18 |    19 |
 
 ### Sizes
 
-| Artifact         |        1k |        2k |        4k |          8k |
-| ---------------- | --------: | --------: | --------: | ----------: |
+| Artifact            |        1k |        2k |        4k |          8k |
+| ------------------- | --------: | --------: | --------: | ----------: |
 | Prepare Proving Key | 257.22 MB | 407.18 MB | 773.90 MB | 1,512.03 MB |
 | Show Proving Key    |   2.96 MB |   2.96 MB |   2.96 MB |     2.96 MB |
 | Prepare Proof       |  75.93 KB | 109.41 KB | 175.90 KB |   308.38 KB |


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior? (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?) -->

This PR updates the OpenAC implementation benchmarks after integrating the feature of comparing values within the same credential.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Re #78 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-ethereum/zkID/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
