### PR TITLE
specs: rename spec 2 folder + spec 3 protocol-name to match titles

### DIFF
--- a/specs/2-zk-proof-of-personhood/README.md
+++ b/specs/2-zk-proof-of-personhood/README.md
@@ -343,7 +343,7 @@ This section specifies the network interface that conforming verifiers SHOULD ex
 
 The Verifier API does not modify the cryptographic protocol or circuit relations defined in [Specification](#specification). It defines the wire-level operations needed to deliver challenges to provers, accept proof submissions, expose deployment state, and report errors.
 
-This section describes the 2-party deployment topology (relying party ↔ verifier). Other deployment topologies (e.g., 3-party flows where a wallet mediates between a merchant and the verifier, as in 3/ZK-AGE-ELIGIBILITY) are out of scope for this version. Where applicable, the term `challenge` used here corresponds to the verifier-issued nonce used elsewhere in OpenAC-based flows.
+This section describes the 2-party deployment topology (relying party ↔ verifier). Other deployment topologies (e.g., 3-party flows where a wallet mediates between a merchant and the verifier, as in 3/ZK-AGE-VERIFICATION) are out of scope for this version. Where applicable, the term `challenge` used here corresponds to the verifier-issued nonce used elsewhere in OpenAC-based flows.
 
 ### Operations
 

--- a/specs/3-zk-age-verification/README.md
+++ b/specs/3-zk-age-verification/README.md
@@ -1,7 +1,7 @@
 ---
 slug: 3
-title: 3/ZK-AGE-ELIGIBILITY
-name: Wallet-Based Age Eligibility Verification for Third-Party Services
+title: 3/ZK-AGE-VERIFICATION
+name: Wallet-Based Age Verification for Third-Party Services
 status: raw
 category: Standards Track
 tags: zero-knowledge, age-verification, privacy, anonymous-credentials, openac, alcohol-purchase
@@ -22,7 +22,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-This specification defines an OpenAC-based privacy-preserving age-eligibility verification protocol for wallet-based proof presentation to third-party services.
+This specification defines an OpenAC-based privacy-preserving age-verification protocol for wallet-based proof presentation to third-party services.
 
 In the MVP scope, the holder proves possession of a valid Driver License verifiable credential without disclosing raw identity attributes to the merchant.
 
@@ -34,11 +34,11 @@ The protocol adopts the OpenAC prepare-reblind-show model and includes device bi
 
 Online alcohol purchase flows require age gating, while minimizing unnecessary disclosure of identity data to merchants.
 
-This specification defines a primitive that separates eligibility verification from raw identity disclosure by using an OpenAC-based zero-knowledge proof flow integrated with a wallet-based user experience.
+This specification defines a primitive that separates age verification from raw identity disclosure by using an OpenAC-based zero-knowledge proof flow integrated with a wallet-based user experience.
 
 # OpenAC Profile
 
-This specification defines an application profile of OpenAC for age-eligibility verification.
+This specification defines an application profile of OpenAC for age verification.
 
 Conforming implementations MUST:
 
@@ -545,7 +545,7 @@ Specific toolchains such as mobile native bindings, WASM verifier bindings, `mop
 - [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
 - [1/OPENAC](../1-openac/README.md)
 - [OpenAC: Open Design for Transparent and Lightweight Anonymous Credentials](https://github.com/privacy-ethereum/zkID)
-- [2/ZK-HUMAN-VERIFICATION](../2-zk-human-verification/README.md)
+- [2/ZK-PROOF-OF-PERSONHOOD](../2-zk-proof-of-personhood/README.md)
 - [TWDIW-integration](https://github.com/zkmopro/TWDIW-integration)
 - [TWDIW Official App](https://github.com/moda-gov-tw/TWDIW-official-app)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -6,8 +6,8 @@ reference implementation.
 | # | Spec | Status | Summary |
 | - | --- | --- | --- |
 | 1 | `OPENAC` | _in review_ | Reserved for the OpenAC core protocol — under separate review. |
-| 2 | [ZK-HUMAN-VERIFICATION](./2-zk-human-verification/README.md) | raw | ZK-based one-time "verified human" status for online forums, with a deterministic nullifier. |
-| 3 | [ZK-AGE-ELIGIBILITY](./3-zk-age-eligibility/README.md) | raw | Wallet-based age-eligibility verification, profiled on top of OpenAC. Initial scope: Driver License for alcohol-purchase gating. |
+| 2 | [ZK-PROOF-OF-PERSONHOOD](./2-zk-proof-of-personhood/README.md) | raw | ZK-based one-time "verified human" status for online forums, with a deterministic nullifier. |
+| 3 | [ZK-AGE-VERIFICATION](./3-zk-age-verification/README.md) | raw | Wallet-based age verification, profiled on top of OpenAC. Initial scope: Driver License for alcohol-purchase gating. |
 
 ## Change Process
 
@@ -22,5 +22,5 @@ These specs were initially incubated in `privacy-ethereum/zkspecs` and moved
 to this repository so they sit alongside the implementations they describe:
 
 - `1/OPENAC` — to be added under a separate PR; previously drafted as `zkspecs#23` (and earlier `zkspecs#21`).
-- `2/ZK-HUMAN-VERIFICATION` — merged at `zkspecs` `specs/5`; updates carried over from `zkspecs#20`.
-- `3/ZK-AGE-ELIGIBILITY` — previously drafted as `zkspecs#19`.
+- `2/ZK-PROOF-OF-PERSONHOOD` — merged at `zkspecs` `specs/5` (as `5/ZK-HUMAN-VERIFICATION`); updates carried over from `zkspecs#20` and renamed to reflect the protocol concept.
+- `3/ZK-AGE-VERIFICATION` — previously drafted as `zkspecs#19` (as `6/ZK-AGE-ELIGIBILITY`); renamed to reflect that the protocol verifies age, while merchant-decision-level "eligibility" wording is preserved in the spec body.


### PR DESCRIPTION
## Summary

Aligns spec directories and index references with the existing spec
titles. Both spec READMEs were already named in their frontmatter, but
the folder names and the index/cross-reference text lagged behind.

## Spec 2: `ZK-HUMAN-VERIFICATION` → `ZK-PROOF-OF-PERSONHOOD`

- Rename `specs/2-zk-human-verification/` →
  `specs/2-zk-proof-of-personhood/` (`git mv`, history preserved).
- The README on `main` already reads `title: 2/ZK-PROOF-OF-PERSONHOOD`;
  only the folder and references needed catching up.

## Spec 3: `ZK-AGE-ELIGIBILITY` → `ZK-AGE-VERIFICATION`

- Rename `specs/3-zk-age-eligibility/` → `specs/3-zk-age-verification/`
  (`git mv`, history preserved).
- Frontmatter `title` and `name` updated.
- **Five protocol-name references** in the body (Abstract, Motivation,
  OpenAC Profile) updated.
- **14 merchant-decision-level uses** of "eligibility / eligible /
  ineligible" in the body are PRESERVED. Those refer to the merchant's
  per-order acceptance decision (e.g. "minimal eligibility result
  (pass/fail)", "Eligibility Scope", "marks the current checkout as
  eligible or ineligible"), not the verification protocol itself. The
  protocol name change is about what the protocol *does* — verify age
  — while the merchant outcome of that verification remains an
  eligibility decision.

## Shared

- `specs/README.md`: both index rows and editorial-history lines
  updated; prior spec names recorded for traceability.
- Cross-reference link in `specs/2-zk-proof-of-personhood/README.md`
  updated to `3/ZK-AGE-VERIFICATION`.
- Cross-reference link in `specs/3-zk-age-verification/README.md`
  updated to `2/ZK-PROOF-OF-PERSONHOOD`.

## Out of scope

- External-repo URLs in spec 2 (e.g. `zkmopro/ZK-based-Human-Verification`)
  are external repository names and stay as-is.
- No protocol semantics or normative text was changed beyond the
  name itself.

## Test plan

- [x] `git mv` used for both folder renames so file history follows.
- [x] No remaining stale `zk-human-verification` / `zk-age-eligibility`
  path references in `specs/`.
- [x] Only `ZK-AGE-ELIGIBILITY` reference remaining is the intentional
  one in the editorial-history line of `specs/README.md`.
- [x] All 14 merchant-decision-level "eligibility" usages in spec 3
  preserved verbatim.
