### PR TITLE
Repoint MOICA revocation SMT references to privacy-ethereum org

### DIFF
--- a/wallet-unit-poc/circom/SPEC.md
+++ b/wallet-unit-poc/circom/SPEC.md
@@ -86,7 +86,7 @@ All other signals (user cert bytes, RSA signatures, SMT proof path,
 
 Revocation uses a Sparse Merkle Tree non-membership proof against the SMT
 maintained by the
-[`moica-revocation-smt`](https://github.com/moven0831/moica-revocation-smt)
+[`moica-revocation-smt`](https://github.com/privacy-ethereum/moica-revocation-smt)
 service. Circuit A verifies that the cert's `serialNumber` is not present in
 the tree rooted at `smtRoot`.
 

--- a/wallet-unit-poc/web/README.md
+++ b/wallet-unit-poc/web/README.md
@@ -141,11 +141,11 @@ per-issuer snapshot is only known at that point):
 - `/smt-snapshot/g3-tree-snapshot.bin.gz` (~21 MB gzipped; MOICA-G3 only)
 
 SMT-side digests come from
-`https://api.github.com/repos/moven0831/moica-revocation-smt/releases/tags/snapshot-latest`.
+`https://api.github.com/repos/privacy-ethereum/moica-revocation-smt/releases/tags/snapshot-latest`.
 
 In dev, `/keys/*` is proxied to `https://github.com/zkmopro/zkID/releases/download/latest/<asset>`
 and `/smt-snapshot/*` is proxied to
-`https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/<asset>`
+`https://github.com/privacy-ethereum/moica-revocation-smt/releases/download/snapshot-latest/<asset>`
 via `vite.config.ts`. In prod, configure your host to serve those two paths
 same-origin (either via a reverse proxy, or by caching the release assets on a
 CORS-enabled origin you control). Pointing either env var directly at a bare
@@ -207,7 +207,7 @@ Production needs three things the dev proxy provides for free:
 2. **A reverse proxy from `/hipki/*` to the user's `localhost:61161`** so
    browser fetches are same-origin and bypass HiPKI's missing CORS headers.
 3. **A reverse proxy from `/smt-snapshot/*`** to
-   `https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/`
+   `https://github.com/privacy-ethereum/moica-revocation-smt/releases/download/snapshot-latest/`
    (or set `VITE_SMT_SNAPSHOT_BASE_URL` to an absolute URL on a CORS-enabled
    host). GitHub Release CORS behaviour is not a contract the app relies on.
 

--- a/wallet-unit-poc/web/e2e/mock-services.ts
+++ b/wallet-unit-poc/web/e2e/mock-services.ts
@@ -186,7 +186,7 @@ export async function installMockServices(
 const KEYS_RELEASE_API =
   "https://api.github.com/repos/zkmopro/zkID/releases/tags/latest";
 const SMT_RELEASE_API =
-  "https://api.github.com/repos/moven0831/moica-revocation-smt/releases/tags/snapshot-latest";
+  "https://api.github.com/repos/privacy-ethereum/moica-revocation-smt/releases/tags/snapshot-latest";
 
 const KEYS_FIXTURE_FILES = [
   "certChainRS2048_proving.key.gz",

--- a/wallet-unit-poc/web/src/manifest.test.ts
+++ b/wallet-unit-poc/web/src/manifest.test.ts
@@ -16,7 +16,7 @@ import {
 const KEYS_API =
   "https://api.github.com/repos/zkmopro/zkID/releases/tags/latest";
 const SMT_API =
-  "https://api.github.com/repos/moven0831/moica-revocation-smt/releases/tags/snapshot-latest";
+  "https://api.github.com/repos/privacy-ethereum/moica-revocation-smt/releases/tags/snapshot-latest";
 
 interface FakeAsset {
   name: string;

--- a/wallet-unit-poc/web/src/manifest.ts
+++ b/wallet-unit-poc/web/src/manifest.ts
@@ -57,7 +57,7 @@ export const SMT_WASM_EXEC = { url: "/smt-snapshot/wasm_exec.js" };
 const KEYS_RELEASE_API =
   "https://api.github.com/repos/zkmopro/zkID/releases/tags/latest";
 const SMT_RELEASE_API =
-  "https://api.github.com/repos/moven0831/moica-revocation-smt/releases/tags/snapshot-latest";
+  "https://api.github.com/repos/privacy-ethereum/moica-revocation-smt/releases/tags/snapshot-latest";
 
 export type DigestMap = Record<string, string>;
 

--- a/wallet-unit-poc/web/src/smt-snapshot.ts
+++ b/wallet-unit-poc/web/src/smt-snapshot.ts
@@ -16,7 +16,7 @@
 //     Leaf:   [33:65] key, [65:97] value,
 //             [97:129] entryMark                 (129 bytes total)
 //
-// Upstream source: moven0831/moica-revocation-smt server/internal/snapshot/binary.go
+// Upstream source: privacy-ethereum/moica-revocation-smt server/internal/snapshot/binary.go
 
 import { bytesToHex } from "./bytes";
 

--- a/wallet-unit-poc/web/vite.config.ts
+++ b/wallet-unit-poc/web/vite.config.ts
@@ -12,7 +12,7 @@ import {
 
 const RELEASE_BASE = "https://github.com/zkmopro/zkID/releases/download/latest";
 const SMT_SNAPSHOT_RELEASE_BASE =
-  "https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest";
+  "https://github.com/privacy-ethereum/moica-revocation-smt/releases/download/snapshot-latest";
 
 // COOP is scoped per URL so that the sign route keeps `window.opener` alive
 // for the HiPKI popup while the proving route runs in a cross-origin-isolated


### PR DESCRIPTION
## Context

The MOICA revocation SMT repo moved from `github.com/moven0831/moica-revocation-smt` (a personal account) to `github.com/privacy-ethereum/moica-revocation-smt`. This repoints the references in `wallet-unit-poc/`.

The repo **name** (`moica-revocation-smt`) and release **tag** (`snapshot-latest`) are unchanged — only the **owner** moved — so this is a single exact-string swap `moven0831/moica-revocation-smt` → `privacy-ethereum/moica-revocation-smt`.

## Changes (all under `wallet-unit-poc/`)
- `web/src/manifest.ts` + `web/src/manifest.test.ts` — GitHub API releases endpoint (constant + matching test fixture)
- `web/vite.config.ts` — release-asset base URL (dev proxy)
- `web/e2e/mock-services.ts` — Playwright mock endpoint
- `web/src/smt-snapshot.ts` — upstream-source attribution comment
- `web/README.md`, `circom/SPEC.md` — doc links

Bare `moica-revocation-smt` mentions (no owner) are left as-is — still correct.

## Verification
- New location confirmed: `privacy-ethereum/moica-revocation-smt` `snapshot-latest` release serves all assets (`g3-tree-snapshot.json.gz`, `smt.wasm`, …) → HTTP 200.
- `manifest.ts` constant and `manifest.test.ts` fixture updated together (the matching web app PTT-OpenAC-Web's identical test passes: 40/40).
- `rg moven0831` → no matches remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)